### PR TITLE
Fix double hashing during signup

### DIFF
--- a/server/src/routes/auth-routes.ts
+++ b/server/src/routes/auth-routes.ts
@@ -48,11 +48,9 @@ export const signUp = async (req: Request, res: Response) => {
     // Extract username, email and password from request body
     const { username, email, password } = req.body;
 
-    // Hash the password before storing it
-    const hashedPassword = await bcrypt.hash(password, 10);
-
     // Create user in the database with provided details
-    const newUser = await User.create({ username, email, password: hashedPassword });
+    // Password hashing is handled by the User model hook
+    const newUser = await User.create({ username, email, password });
 
     // Get secret key from .env
     const secretKey = process.env.JWT_SECRET_KEY || '';


### PR DESCRIPTION
## Summary
- prevent double hashing of passwords during signup

## Testing
- `npm run server:build`


------
https://chatgpt.com/codex/tasks/task_e_6898d2a00f108321842cf858f1fc46e5